### PR TITLE
Update numpy requirements

### DIFF
--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -6,7 +6,7 @@
   "requirements": [
     "websocket-client>=0.58.0",
     "wakeonlan>=2.0.0",
-    "numpy>=1.19.2",
+    "numpy>=1.21.1",
     "aiofiles>=0.6.0"
   ],
   "dependencies": [],


### PR DESCRIPTION
It's related to issue with InfluxDB integration. InfluxDB use newer version of numpy and with current version in this component InfluxDB making errors and not working properly.
It's related to this issue: https://github.com/home-assistant/core/issues/52859