### PR TITLE
Add exit key code

### DIFF
--- a/docs/Key_codes.md
+++ b/docs/Key_codes.md
@@ -91,6 +91,7 @@ KEY_LEFT|NavigationLeft
 KEY_RIGHT|NavigationRight
 KEY_RETURN|NavigationReturn/Back
 KEY_ENTER|NavigationEnter
+KEY_EXIT|NevigationExit
 
 *Media Keys*
 ____________


### PR DESCRIPTION
When replicating my Samsung TV remote, I was not able to find the "Exit" button key in the list. After trying, the "KEY_EXIT" worked for me.