### PR TITLE
Improve external sensor

### DIFF
--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -504,7 +504,7 @@ class SamsungTVDevice(MediaPlayerEntity):
         ext_state = self.hass.states.get(ext_entity)
         if not ext_state:
             return True
-        return ext_state.state == STATE_ON
+        return ext_state.state != STATE_OFF
 
     def _ping_device(self):
         """Ping TV with WS and others method to check power status."""


### PR DESCRIPTION
When you use `binary_sensor` for TV power status detection, in some situations the sensor itself can become `unavailable` or `unknown`. When that happens, TV will be shown as `off` when in reality it's `on`. 

This PR fixes the issue. I made a change, which will always return `True` when external sensor state is checked, unless external sensor state is `off`.