### PR TITLE
Add "integration_type" property to manifest

### DIFF
--- a/custom_components/samsungtv_smart/const.py
+++ b/custom_components/samsungtv_smart/const.py
@@ -22,7 +22,7 @@ class PowerOnMethod(Enum):
 DOMAIN = "samsungtv_smart"
 
 MIN_HA_MAJ_VER = 2022
-MIN_HA_MIN_VER = 10
+MIN_HA_MIN_VER = 11
 __min_ha_version__ = f"{MIN_HA_MAJ_VER}.{MIN_HA_MIN_VER}.0"
 
 DATA_CFG_YAML = "cfg_yaml"

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -16,5 +16,6 @@
   ],
   "config_flow": true,
   "iot_class": "cloud_polling",
-  "version": "0.8.1"
+  "integration_type": "device",
+  "version": "0.9.0b1"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "SamsungTV Smart",
   "content_in_root": false,
-  "homeassistant": "2022.10.0"
+  "homeassistant": "2022.11.0"
 }


### PR DESCRIPTION
Add "integration_type" property to manifest and set minimum HA required version to 2022.11