### PR TITLE
Review power status detection and control

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,6 @@ Use `Rest API Call` only if the other 2 methods do not work.<br/>
 This option allow to configure the number of time the WOL packet is sent to turn on TV. Increase the value
 until the TV properly turn-on.<br/>
 
-- **Seconds to delay power ON status**<br/>
-(default = 30, range from 0 to 60)<br/>
-This option allow to configure a delay to wait before setting the TV status to ON. This is used to avoid false
-ON status for TV that enable the network interface on regular interval also when the TV status is OFF.<br/>
-
 - **TCP port used to check power status**<br/>
 (default = 0, range from 0 to 65535)<br/>
 With this option is possible to check the availability of a specific port to determinate power status instead

--- a/custom_components/samsungtv_smart/api/samsungws.py
+++ b/custom_components/samsungtv_smart/api/samsungws.py
@@ -20,6 +20,8 @@ Copyright (C) 2020 Ollo69
     Boston, MA  02110-1335  USA
 
 """
+from __future__ import annotations
+
 import base64
 from datetime import datetime
 from enum import Enum
@@ -229,14 +231,16 @@ class SamsungTVWS:
 
     def __init__(
         self,
-        host,
-        token=None,
-        token_file=None,
-        port=8001,
-        timeout=None,
-        key_press_delay=1.0,
-        name="SamsungTvRemote",
-        app_list=None,
+        host: str,
+        *,
+        token: str | None = None,
+        token_file: str | None = None,
+        port: int | None = 8001,
+        timeout: int | None = None,
+        key_press_delay: float | None = 1.0,
+        name: str | None = "SamsungTvRemote",
+        app_list: dict | None = None,
+        ping_port: int | None = 0,
     ):
         """Initialize SamsungTVWS object."""
         self.host = host
@@ -244,10 +248,12 @@ class SamsungTVWS:
         self.token_file = token_file
         self.port = port or 8001
         self.timeout = None if timeout == 0 else timeout
-        self.key_press_delay = key_press_delay
+        self.key_press_delay = 1.0 if key_press_delay is None else key_press_delay
         self.name = name or "SamsungTvRemote"
+        self._app_list = dict(app_list) if app_list else None
+        self._ping_port = ping_port or 0
+
         self.connection = None
-        self._app_list = app_list
         self._artmode_status = ArtModeStatus.Unsupported
         self._power_on_requested = False
         self._power_on_requested_time = datetime.min
@@ -263,7 +269,6 @@ class SamsungTVWS:
 
         self._ping_thread = None
         self._ping_thread_run = False
-        self._ping_port = 9197
 
         self._ws_remote = None
         self._client_remote = None
@@ -321,6 +326,16 @@ class SamsungTVWS:
                 query["token"] = token
         ws_query = urlencode(query)
         return f"{ws_uri}?{ws_query}"
+
+    def set_ping_port(self, port: int):
+        """Set a new ping port."""
+        self._ping_port = port
+
+    def update_app_list(self, app_list: dict | None):
+        """Update application list."""
+        if not app_list:
+            self._app_list = None
+        self._app_list = dict(app_list)
 
     def register_new_token_callback(self, func):
         """Register a callback function."""

--- a/custom_components/samsungtv_smart/api/samsungws.py
+++ b/custom_components/samsungtv_smart/api/samsungws.py
@@ -35,6 +35,7 @@ from typing import Any
 from urllib.parse import urlencode, urljoin
 import uuid
 
+import aiohttp
 import requests
 import websocket
 
@@ -81,6 +82,19 @@ def kill_subprocess(
     process.wait()
 
     del process
+
+
+def _process_api_response(response, *, raise_error=True):
+    """Process response received by TV."""
+    try:
+        return json.loads(response)
+    except json.JSONDecodeError as exc:
+        _LOGGING.debug("Failed to parse response from TV. response text: %s", response)
+        if raise_error:
+            raise ResponseError(
+                "Failed to parse response from TV. Maybe feature not supported on this model"
+            ) from exc
+    return response
 
 
 class Ping:
@@ -151,6 +165,65 @@ class ArtModeStatus(Enum):
     On = 3
 
 
+class SamsungTVAsyncRest:
+    """Class that implement rest request in async."""
+
+    def __init__(
+        self,
+        host: str,
+        session: aiohttp.ClientSession,
+        timeout=None,
+    ) -> None:
+        """Initialize the class."""
+        self._host = host
+        self._session = session
+        self._timeout = None if timeout == 0 else timeout
+
+    async def _rest_request(self, target: str, method: str = "GET") -> dict[str, Any]:
+        """Perform async rest request."""
+        url = _format_rest_url(self._host, target)
+        try:
+            if method == "POST":
+                req = self._session.post(url, timeout=self._timeout, verify_ssl=False)
+            elif method == "PUT":
+                req = self._session.put(url, timeout=self._timeout, verify_ssl=False)
+            elif method == "DELETE":
+                req = self._session.delete(url, timeout=self._timeout, verify_ssl=False)
+            else:
+                req = self._session.get(url, timeout=self._timeout, verify_ssl=False)
+            async with req as resp:
+                return _process_api_response(await resp.text())
+        except aiohttp.ClientConnectionError as ex:
+            raise HttpApiError(
+                "TV unreachable or feature not supported on this model."
+            ) from ex
+
+    async def async_rest_device_info(self) -> dict[str, Any]:
+        """Get device info using rest api call."""
+        _LOGGING.debug("Get device info via rest api")
+        return await self._rest_request("")
+
+    async def async_rest_app_status(self, app_id: str) -> dict[str, Any]:
+        """Get app status using rest api call."""
+        _LOGGING.debug("Get app %s status via rest api", app_id)
+        return await self._rest_request("applications/" + app_id)
+
+    async def async_rest_app_run(self, app_id: str) -> dict[str, Any]:
+        """Run an app using rest api call."""
+        _LOGGING.debug("Run app %s via rest api", app_id)
+        return await self._rest_request("applications/" + app_id, "POST")
+
+    async def async_rest_app_close(self, app_id: str) -> dict[str, Any]:
+        """Close an app using rest api call."""
+        _LOGGING.debug("Close app %s via rest api", app_id)
+        return await self._rest_request("applications/" + app_id, "DELETE")
+
+    async def async_rest_app_install(self, app_id: str) -> dict[str, Any]:
+        """Install a new app using rest api call."""
+        _LOGGING.debug("Install app %s via rest api", app_id)
+        return await self._rest_request("applications/" + app_id, "PUT")
+
+
 class SamsungTVWS:
     """Class to manage websocket communication with tizen TV."""
 
@@ -188,6 +261,10 @@ class SamsungTVWS:
         self._last_app_scan = datetime.min
         self._is_connected = False
 
+        self._ping_thread = None
+        self._ping_thread_run = False
+        self._ping_port = 9197
+
         self._ws_remote = None
         self._client_remote = None
         self._last_ping = datetime.min
@@ -202,6 +279,7 @@ class SamsungTVWS:
         self._client_art_supported = 2
 
         self._ping = Ping(self.host)
+        self._status_callback = None
         self._new_token_callback = None
 
     def __enter__(self):
@@ -248,6 +326,14 @@ class SamsungTVWS:
         """Register a callback function."""
         self._new_token_callback = func
 
+    def register_status_callback(self, func):
+        """Register callback function used on status change."""
+        self._status_callback = func
+
+    def unregister_status_callback(self):
+        """Unregister callback function used on status change."""
+        self._status_callback = None
+
     def _get_token(self):
         """Get current token."""
         if self.token_file is not None:
@@ -288,7 +374,7 @@ class SamsungTVWS:
         elif ws_socket:
             connection = ws_socket
         else:
-            self.start_client(start_all=True)
+            self._start_client(start_all=True)
             return False
 
         payload = json.dumps(command)
@@ -298,7 +384,7 @@ class SamsungTVWS:
             _LOGGING.warning("_ws_send: connection is closed, send command failed")
             if using_remote or use_control:
                 _LOGGING.info("_ws_send: try to restart communication threads")
-                self.start_client(start_all=use_control)
+                self._start_client(start_all=use_control)
             return False
         except websocket.WebSocketTimeoutException:
             _LOGGING.warning("_ws_send: timeout error sending command %s", payload)
@@ -321,32 +407,18 @@ class SamsungTVWS:
         url = _format_rest_url(self.host, target)
         try:
             if method == "POST":
-                return requests.post(url, timeout=self.timeout)
+                response = requests.post(url, timeout=self.timeout)
             elif method == "PUT":
-                return requests.put(url, timeout=self.timeout)
+                response = requests.put(url, timeout=self.timeout)
             elif method == "DELETE":
-                return requests.delete(url, timeout=self.timeout)
+                response = requests.delete(url, timeout=self.timeout)
             else:
-                return requests.get(url, timeout=self.timeout)
+                response = requests.get(url, timeout=self.timeout)
         except requests.ConnectionError as exc:
             raise HttpApiError(
                 "TV unreachable or feature not supported on this model."
             ) from exc
-
-    @staticmethod
-    def _process_api_response(response, *, raise_error=True):
-        """Process response received by TV via websocket channel."""
-        try:
-            return json.loads(response)
-        except json.JSONDecodeError as exc:
-            _LOGGING.debug(
-                "Failed to parse response from TV. response text: %s", response
-            )
-            if raise_error:
-                raise ResponseError(
-                    "Failed to parse response from TV. Maybe feature not supported on this model"
-                ) from exc
-        return response
+        return _process_api_response(response.text, raise_error=False)
 
     def _check_conn_id(self, resp_data):
         """Check if returned connection id from WS server is valid for this TV."""
@@ -395,6 +467,8 @@ class SamsungTVWS:
         # on socket. TV do not answer to ping but send ping to client
         self._run_forever(self._ws_remote, sslopt=sslopt, ping_interval=3600)
         self._is_connected = False
+        if self._status_callback is not None:
+            self._status_callback()
         if self._ws_art:
             self._ws_art.close()
         if self._ws_control:
@@ -415,7 +489,7 @@ class SamsungTVWS:
 
     def _on_message_remote(self, _, message):
         """Manage messages received by remote WS connection."""
-        response = self._process_api_response(message)
+        response = _process_api_response(message)
         _LOGGING.debug(response)
         event = response.get("event")
         if not event:
@@ -434,7 +508,9 @@ class SamsungTVWS:
                 self._set_token(token)
             self._is_connected = True
             self._request_apps_list()
-            self.start_client(start_all=True)
+            self._start_client(start_all=True)
+            if self._status_callback is not None:
+                self._status_callback()
         elif event == "ed.installedApp.get":
             _LOGGING.debug("Message remote: received installedApp")
             self._handle_installed_app(response)
@@ -501,7 +577,7 @@ class SamsungTVWS:
 
     def _on_message_control(self, _, message):
         """Manage messages received by control WS channel."""
-        response = self._process_api_response(message)
+        response = _process_api_response(message)
         _LOGGING.debug(response)
         result = response.get("result")
         if result:
@@ -629,7 +705,7 @@ class SamsungTVWS:
 
     def _on_message_art(self, _, message):
         """Manage messages received by art WS channel."""
-        response = self._process_api_response(message)
+        response = _process_api_response(message)
         _LOGGING.debug(response)
         event = response.get("event")
         if not event:
@@ -677,7 +753,7 @@ class SamsungTVWS:
         data_str = response.get("data")
         if not data_str:
             return
-        data = self._process_api_response(data_str)
+        data = _process_api_response(data_str)
         event = data.get("event", "")
         if event == "art_mode_changed":
             status = data.get("status", "")
@@ -729,32 +805,36 @@ class SamsungTVWS:
         """Return current running app."""
         return self._running_app
 
-    def ping_device(self, port=0):
-        """Ping TV device to check current status, and return boolean.
-        If port is specified, try to open specific port
-        for check, otherwise it uses ICMP echo
-        If check is True, try to open WS connection
-        """
-        result = self._ping.ping(port)
-        # check ws ping/pong
-        call_time = datetime.utcnow()
-        if result and self._ws_remote:
-            difference = (call_time - self._last_ping).total_seconds()
-            result = difference < MAX_WS_PING_INTERVAL
+    def _ping_thread_method(self):
+        """Start the ping thread that check the TV status."""
+        ping = Ping(self.host)
+        while self._ping_thread_run:
+            if ping.ping(self._ping_port):
+                if not self._is_connected:
+                    self._start_client()
+                else:
+                    self._check_remote()
+            else:
+                if self._is_connected:
+                    self.stop_client()
+            time.sleep(1.0)
 
-        if not result:
-            self.stop_client()
-            if self._artmode_status != ArtModeStatus.Unsupported:
-                self._artmode_status = ArtModeStatus.Unavailable
-        elif self._ws_remote:
-            self._check_art_mode()
+    def _check_remote(self):
+        """Check current remote thread status."""
+        call_time = datetime.utcnow()
+        if self._ws_remote:
+            difference = (call_time - self._last_ping).total_seconds()
+            if difference >= MAX_WS_PING_INTERVAL:
+                self.stop_client()
+                if self._artmode_status != ArtModeStatus.Unsupported:
+                    self._artmode_status = ArtModeStatus.Unavailable
+            else:
+                self._check_art_mode()
 
         if self._power_on_requested:
             difference = (call_time - self._power_on_requested_time).total_seconds()
             if difference > self._power_on_delay:
                 self._power_on_requested = False
-
-        return result
 
     def _check_art_mode(self):
         """Check current art mode and start related control thread if required."""
@@ -766,7 +846,7 @@ class SamsungTVWS:
                 self._artmode_status = ArtModeStatus.Unavailable
                 self._ws_art.close()
         elif self._ws_remote:
-            self.start_client(start_all=True)
+            self._start_client(start_all=True)
 
     def set_power_on_request(self, set_art_mode=False, power_on_delay=0):
         """Set a power on request status and save the time of the rquest."""
@@ -811,7 +891,25 @@ class SamsungTVWS:
         for app in app_to_check.values():
             self._get_app_status(app.app_id, app.app_type)
 
-    def start_client(self, *, start_all=False):
+    def start_poll(self):
+        """Start polling the TV for status."""
+        if self._ping_thread is None or not self._ping_thread.is_alive():
+            self._ping_thread = Thread(target=self._ping_thread_method)
+            self._ping_thread.name = "SamsungPing"
+            self._ping_thread.daemon = True
+            self._ping_thread_run = True
+            self._ping_thread.start()
+
+    def stop_poll(self):
+        """Stop polling the TV for status."""
+        if self._ping_thread is not None and not self._ping_thread.is_alive():
+            self._ping_thread_run = False
+            self._ping_thread.join()
+            if self._is_connected:
+                self.stop_client()
+            self._ping_thread = None
+
+    def _start_client(self, *, start_all=False):
         """Start all thread that connect to the TV websocket"""
 
         if self._client_remote is None or not self._client_remote.is_alive():
@@ -860,7 +958,7 @@ class SamsungTVWS:
         response = ""
 
         for _ in range(3):
-            response = self._process_api_response(connection.recv())
+            response = _process_api_response(connection.recv())
             _LOGGING.debug(response)
             event = response.get("event", "-")
             if event != "ms.channel.connect":
@@ -1004,39 +1102,34 @@ class SamsungTVWS:
         )
 
     def open_browser(self, url):
-        """Launche the browser app on the TV."""
+        """Launch the browser app on the TV."""
         _LOGGING.debug("Opening url in browser %s", url)
         return self.run_app("org.tizen.browser", TYPE_NATIVE_LAUNCH, url)
 
     def rest_device_info(self):
         """Get device info using rest api call."""
         _LOGGING.debug("Get device info via rest api")
-        response = self._rest_request("")
-        return self._process_api_response(response.text, raise_error=False)
+        return self._rest_request("")
 
     def rest_app_status(self, app_id):
         """Get app status using rest api call."""
         _LOGGING.debug("Get app %s status via rest api", app_id)
-        response = self._rest_request("applications/" + app_id)
-        return self._process_api_response(response.text, raise_error=False)
+        return self._rest_request("applications/" + app_id)
 
     def rest_app_run(self, app_id):
         """Run an app using rest api call."""
         _LOGGING.debug("Run app %s via rest api", app_id)
-        response = self._rest_request("applications/" + app_id, "POST")
-        return self._process_api_response(response.text, raise_error=False)
+        return self._rest_request("applications/" + app_id, "POST")
 
     def rest_app_close(self, app_id):
         """Close an app using rest api call."""
         _LOGGING.debug("Close app %s via rest api", app_id)
-        response = self._rest_request("applications/" + app_id, "DELETE")
-        return self._process_api_response(response.text, raise_error=False)
+        return self._rest_request("applications/" + app_id, "DELETE")
 
     def rest_app_install(self, app_id):
         """Install a new app using rest api call."""
         _LOGGING.debug("Install app %s via rest api", app_id)
-        response = self._rest_request("applications/" + app_id, "PUT")
-        return self._process_api_response(response.text, raise_error=False)
+        return self._rest_request("applications/" + app_id, "PUT")
 
     def shortcuts(self):
         """Return a list of available shortcuts."""

--- a/custom_components/samsungtv_smart/config_flow.py
+++ b/custom_components/samsungtv_smart/config_flow.py
@@ -52,7 +52,6 @@ from .const import (
     CONF_EXT_POWER_ENTITY,
     CONF_LOGO_OPTION,
     CONF_PING_PORT,
-    CONF_POWER_ON_DELAY,
     CONF_POWER_ON_METHOD,
     CONF_SHOW_CHANNEL_NR,
     CONF_SOURCE_LIST,
@@ -65,7 +64,6 @@ from .const import (
     CONF_USE_ST_STATUS_INFO,
     CONF_WOL_REPEAT,
     CONF_WS_NAME,
-    DEFAULT_POWER_ON_DELAY,
     DOMAIN,
     MAX_WOL_REPEAT,
     RESULT_ST_DEVICE_NOT_FOUND,
@@ -117,7 +115,6 @@ ADVANCED_OPTIONS = [
     CONF_EXT_POWER_ENTITY,
     CONF_PING_PORT,
     CONF_WOL_REPEAT,
-    CONF_POWER_ON_DELAY,
     CONF_TOGGLE_ART_MODE,
     CONF_USE_MUTE_CHECK,
 ]
@@ -677,10 +674,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_WOL_REPEAT,
                     default=min(options.get(CONF_WOL_REPEAT, 1), MAX_WOL_REPEAT),
                 ): vol.All(vol.Coerce(int), vol.Clamp(min=1, max=MAX_WOL_REPEAT)),
-                vol.Required(
-                    CONF_POWER_ON_DELAY,
-                    default=options.get(CONF_POWER_ON_DELAY, DEFAULT_POWER_ON_DELAY),
-                ): vol.All(vol.Coerce(int), vol.Clamp(min=0, max=60)),
                 vol.Required(
                     CONF_PING_PORT, default=options.get(CONF_PING_PORT, 0)
                 ): vol.All(vol.Coerce(int), vol.Clamp(min=0, max=65535)),

--- a/custom_components/samsungtv_smart/const.py
+++ b/custom_components/samsungtv_smart/const.py
@@ -47,7 +47,6 @@ CONF_EXT_POWER_ENTITY = "ext_power_entity"
 CONF_LOAD_ALL_APPS = "load_all_apps"
 CONF_LOGO_OPTION = "logo_option"
 CONF_PING_PORT = "ping_port"
-CONF_POWER_ON_DELAY = "power_on_delay"
 CONF_POWER_ON_METHOD = "power_on_method"
 CONF_SHOW_CHANNEL_NR = "show_channel_number"
 CONF_SOURCE_LIST = "source_list"
@@ -68,7 +67,6 @@ CONF_SCAN_APP_HTTP = "scan_app_http"
 
 DEFAULT_APP = "TV/HDMI"
 DEFAULT_PORT = 8001
-DEFAULT_POWER_ON_DELAY = 30
 DEFAULT_SOURCE_LIST = {"TV": "KEY_TV", "HDMI": "KEY_HDMI"}
 DEFAULT_TIMEOUT = 6
 

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -1,9 +1,12 @@
 """Support for interface with an Samsung TV."""
+from __future__ import annotations
+
 import asyncio
 from datetime import datetime, timedelta
 import logging
 from socket import error as socketError
 from time import sleep
+from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 from aiohttp import ClientConnectionError, ClientResponseError, ClientSession
@@ -43,16 +46,16 @@ from homeassistant.const import (
 from homeassistant.core import DOMAIN as HA_DOMAIN, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.service import CONF_SERVICE_ENTITY_ID, async_call_from_config
 from homeassistant.helpers.storage import STORAGE_DIR
 from homeassistant.util import Throttle, dt as dt_util
 from homeassistant.util.async_ import run_callback_threadsafe
 
-from .api.samsungws import ArtModeStatus, SamsungTVWS
+from .api.samsungws import ArtModeStatus, SamsungTVAsyncRest, SamsungTVWS
 from .api.smartthings import SmartThingsTV, STStatus
 from .api.upnp import SamsungUPnP
 from .const import (
@@ -67,7 +70,6 @@ from .const import (
     CONF_EXT_POWER_ENTITY,
     CONF_LOGO_OPTION,
     CONF_PING_PORT,
-    CONF_POWER_ON_DELAY,
     CONF_POWER_ON_METHOD,
     CONF_SHOW_CHANNEL_NR,
     CONF_SOURCE_LIST,
@@ -84,7 +86,6 @@ from .const import (
     DATA_OPTIONS,
     DEFAULT_APP,
     DEFAULT_PORT,
-    DEFAULT_POWER_ON_DELAY,
     DEFAULT_SOURCE_LIST,
     DEFAULT_TIMEOUT,
     DOMAIN,
@@ -125,7 +126,6 @@ MEDIA_TYPE_BROWSER = "browser"
 MEDIA_TYPE_KEY = "send_key"
 MEDIA_TYPE_TEXT = "send_text"
 POWER_OFF_DELAY = 20
-POWER_ON_DELAY = 5
 ST_APP_SEPARATOR = "/"
 ST_UPDATE_TIMEOUT = 5
 
@@ -135,6 +135,7 @@ YT_VIDEO_QS = "v"
 MAX_CONTROLLED_ENTITY = 4
 
 MIN_TIME_BETWEEN_APP_SCANS = timedelta(seconds=60)
+MIN_TIME_BETWEEN_ST_UPDATE = timedelta(seconds=5)
 
 SUPPORT_SAMSUNGTV_SMART = (
     MediaPlayerEntityFeature.PAUSE
@@ -162,7 +163,7 @@ async def async_setup_entry(
     """Set up the Samsung TV from a config entry."""
 
     # session used by aiohttp
-    session = hass.helpers.aiohttp_client.async_get_clientsession()
+    session = async_get_clientsession(hass)
     local_logo_path = hass.data[DOMAIN].get(LOCAL_LOGO_PATH)
 
     config = entry.data.copy()
@@ -249,7 +250,6 @@ class SamsungTVDevice(MediaPlayerEntity):
         """Initialize the Samsung device."""
 
         self._entry_data = entry_data
-        self._session = session
         self._host = config[CONF_HOST]
         self._mac = config.get(CONF_MAC)
 
@@ -280,6 +280,9 @@ class SamsungTVDevice(MediaPlayerEntity):
             )
         )
 
+        # Device information from TV
+        self._device_info: dict[str, Any] | None = None
+
         # Save a reference to the imported config
         self._broadcast = config.get(CONF_BROADCAST_ADDRESS)
 
@@ -291,11 +294,6 @@ class SamsungTVDevice(MediaPlayerEntity):
         # sending the next command to avoid turning the TV back ON).
         self._started_up = False
         self._end_of_power_off = None
-        self._power_on_detected = None
-        self._delay_cancel = None
-        self._set_update_forced = 0
-        self._delay_status_update = False
-        self._update_forced_time = None
         self._fake_on = None
         self._delayed_set_source = None
         self._delayed_set_source_time = None
@@ -325,16 +323,13 @@ class SamsungTVDevice(MediaPlayerEntity):
 
         # ws initialization
         ws_name = config.get(CONF_WS_NAME, self._attr_name)
-        ws_port = config.get(CONF_PORT, DEFAULT_PORT)
-        ws_timeout = config.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
-        ws_token = config.get(CONF_TOKEN)
         self._ws = SamsungTVWS(
             name=f"{WS_PREFIX} {ws_name}",  # this is the name shown in the TV external device.
             host=self._host,
-            port=ws_port,
-            timeout=ws_timeout,
+            port=config.get(CONF_PORT, DEFAULT_PORT),
+            timeout=config.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
             key_press_delay=KEYPRESS_DEFAULT_DELAY,
-            token=ws_token,
+            token=config.get(CONF_TOKEN),
             app_list=self._app_list,
         )
 
@@ -371,9 +366,16 @@ class SamsungTVDevice(MediaPlayerEntity):
             session=session,
         )
 
+    @callback
+    def _status_changed_callback(self):
+        """Called when status changed."""
+        _LOGGER.debug("status_changed_callback called")
+        self.async_schedule_update_ha_state(True)
+
     async def async_added_to_hass(self):
         """Set config parameter when add to hass."""
         await super().async_added_to_hass()
+
         # this will update config options when changed
         self.async_on_remove(
             async_dispatcher_connect(
@@ -381,9 +383,17 @@ class SamsungTVDevice(MediaPlayerEntity):
             )
         )
 
+        def update_status_callback():
+            """Update current TV status."""
+            run_callback_threadsafe(self.hass.loop, self._status_changed_callback)
+
+        self._ws.register_status_callback(update_status_callback)
+        await self.hass.async_add_executor_job(self._ws.start_poll)
+
     async def async_will_remove_from_hass(self):
         """Run when entity will be removed from hass."""
-        await self.hass.async_add_executor_job(self._ws.stop_client)
+        self._ws.unregister_status_callback()
+        await self.hass.async_add_executor_job(self._ws.stop_poll)
 
     @staticmethod
     def _get_add_dev_info(dev_model, dev_name, dev_os, dev_mac):
@@ -471,83 +481,18 @@ class SamsungTVDevice(MediaPlayerEntity):
         option = self._entry_data[DATA_OPTIONS].get(param)
         return default if option is None else option
 
+    def _get_device_spec(self, key: str) -> Any | None:
+        """Check if a flag exists in latest device info."""
+        if not ((info := self._device_info) and (device := info.get("device"))):
+            return None
+        return device.get(key)
+
     def _power_off_in_progress(self):
         """Check if a power off request is in progress."""
         return (
             self._end_of_power_off is not None
             and self._end_of_power_off > dt_util.utcnow()
         )
-
-    def _update_forced(self):
-        """Check if a forced update is required."""
-        if self._delay_status_update:
-            self._delay_status_update = False
-            return True
-
-        if self._delay_cancel:
-            self._delay_cancel()
-            self._delay_cancel = None
-
-        if self._set_update_forced > 0:
-            self._set_update_forced -= 1
-            self._update_forced_time = datetime.utcnow()
-            self._power_on_detected = datetime.min
-            return False
-
-        if not self._update_forced_time:
-            return False
-
-        call_time = datetime.utcnow()
-        difference = (call_time - self._update_forced_time).total_seconds()
-        if difference >= 10:
-            self._update_forced_time = None
-            return False
-        return True
-
-    def _delay_update(self, delay_sec: int):
-        """Delay the update for a specific interval"""
-        if self._set_update_forced <= 0:
-            return
-
-        if self._state == MediaPlayerState.ON:
-            self._set_update_forced = 0
-            return
-
-        @callback
-        def update_status(_):
-            self._delay_status_update = False
-            if self._state != MediaPlayerState.ON:
-                self.async_schedule_update_ha_state(True)
-            else:
-                self._set_update_forced = 0
-
-        self._delay_status_update = True
-        self._delay_cancel = async_call_later(self.hass, delay_sec, update_status)
-
-    def _delay_power_on(self, result):
-        """Manage delay for power on status."""
-        if result and self._state == MediaPlayerState.OFF:
-
-            power_on_delay = self._get_option(
-                CONF_POWER_ON_DELAY, DEFAULT_POWER_ON_DELAY
-            )
-
-            if power_on_delay > 0:
-                if not self._power_on_detected:
-                    self._power_on_detected = datetime.utcnow()
-                    return False
-                difference = (
-                    datetime.utcnow() - self._power_on_detected
-                ).total_seconds()
-                if difference < power_on_delay:
-                    return False
-        else:
-            if self._ws.artmode_status == ArtModeStatus.On:
-                self._power_on_detected = datetime.min
-            else:
-                self._power_on_detected = None
-
-        return result
 
     async def _update_volume_info(self):
         """Update the volume info."""
@@ -570,10 +515,10 @@ class SamsungTVDevice(MediaPlayerEntity):
             return True
         return not self.hass.states.is_state(ext_entity, STATE_OFF)
 
-    def _ping_device(self):
-        """Ping TV with WS and others method to check power status."""
+    def _check_status(self):
+        """Check TV status with WS and others method to check power status."""
 
-        result = self._ws.ping_device(self._ping_port)
+        result = self._ws.is_connected
         if result and self._st:
             if (
                 self._st.state == STStatus.STATE_OFF
@@ -587,15 +532,8 @@ class SamsungTVDevice(MediaPlayerEntity):
             result = self._get_external_entity_status()
 
         if result:
-            self._ws.start_client()
-            self._ws.get_running_app()
-            if (
-                self._ws.artmode_status == ArtModeStatus.On
-                or self._ws.artmode_status == ArtModeStatus.Unavailable
-            ):
+            if self._ws.artmode_status in (ArtModeStatus.On, ArtModeStatus.Unavailable):
                 result = False
-        else:
-            self._ws.stop_client()
 
         return result
 
@@ -817,14 +755,28 @@ class SamsungTVDevice(MediaPlayerEntity):
             _LOGGER.warning("%s - Connection to SmartThings restored", self.entity_id)
         self._st_error_count = 0
 
-    async def async_update(self):
-        """Update state of device."""
-
-        if self._update_forced():
+    async def _async_load_device_info(self) -> None:
+        """Try to gather infos of this TV."""
+        if self._device_info is not None:
             return
 
-        # Required to get source and media title
-        st_error = False
+        rest_api = SamsungTVAsyncRest(
+            host=self._host,
+            session=async_get_clientsession(self.hass),
+            timeout=DEFAULT_TIMEOUT,
+        )
+
+        try:
+            device_info: dict[str, Any] = await rest_api.async_rest_device_info()
+            _LOGGER.debug("Device info on %s is: %s", self._host, device_info)
+            self._device_info = device_info
+        except Exception as ex:  # pylint: disable=broad-except
+            _LOGGER.warning("Error retrieving device info on %s: %s", self._host, ex)
+            self._device_info = {}
+
+    @Throttle(MIN_TIME_BETWEEN_ST_UPDATE)
+    async def _async_st_update(self, **kwargs):
+        """Update SmartThings state of device."""
         if self._st:
             try:
                 async with async_timeout.timeout(ST_UPDATE_TIMEOUT):
@@ -834,11 +786,19 @@ class SamsungTVDevice(MediaPlayerEntity):
                 ClientConnectionError,
                 ClientResponseError,
             ) as ex:
-                st_error = True
                 _LOGGER.debug("%s - SmartThings error: [%s]", self.entity_id, ex)
+                return False
+        return True
 
-        result = await self.hass.async_add_executor_job(self._ping_device)
+    async def async_update(self):
+        """Update state of device."""
 
+        # Required to get source and media title
+        st_error = False
+        if (st_update := await self._async_st_update()) is not None:
+            st_error = not st_update
+
+        result = self._check_status()
         if not self._started_up or not result:
             use_mute_check = False
             self._fake_on = None
@@ -860,9 +820,6 @@ class SamsungTVDevice(MediaPlayerEntity):
                         )
                     result = False
 
-        if self._started_up:
-            result = self._delay_power_on(result)
-
         if result and self._st:
             if self._st.state != STStatus.STATE_ON:
                 st_error = True
@@ -870,11 +827,9 @@ class SamsungTVDevice(MediaPlayerEntity):
 
         self._state = MediaPlayerState.ON if result else MediaPlayerState.OFF
         self._started_up = True
-        self._delay_update(POWER_ON_DELAY)
 
-        if (
-            self.state == MediaPlayerState.ON
-        ):  # NB: We are checking properties, not attribute!
+        # NB: We are checking properties, not attribute!
+        if self.state == MediaPlayerState.ON:
             if self._delayed_set_source:
                 difference = (
                     datetime.utcnow() - self._delayed_set_source_time
@@ -883,6 +838,7 @@ class SamsungTVDevice(MediaPlayerEntity):
                     self._delayed_set_source = None
                 else:
                     await self._async_select_source_delayed(self._delayed_set_source)
+            await self._async_load_device_info()
             await self._update_volume_info()
             self._get_running_app()
             await self._update_media()
@@ -1257,10 +1213,6 @@ class SamsungTVDevice(MediaPlayerEntity):
         if self._state != MediaPlayerState.OFF:
             return True
 
-        self._set_update_forced = (
-            2  # we try to check status 2 times in a shorter interval
-        )
-        self._delay_update(POWER_ON_DELAY)
         await self._async_switch_entity(not set_art_mode)
 
         return True
@@ -1271,6 +1223,12 @@ class SamsungTVDevice(MediaPlayerEntity):
 
     async def async_set_art_mode(self):
         """Turn the media player on setting in art mode."""
+        if (
+            self._state == MediaPlayerState.ON
+            and self._ws.artmode_status == ArtModeStatus.Unsupported
+            and self._get_device_spec("FrameTVSupport") == "true"
+        ):
+            await self.async_send_command("KEY_POWER")
         await self._async_turn_on(True)
 
     def _turn_off(self):
@@ -1282,7 +1240,10 @@ class SamsungTVDevice(MediaPlayerEntity):
         cmd_power_art = "KEY_POWER"
         self._ws.set_power_off_request()
         if self._state == MediaPlayerState.ON:
-            if self._ws.artmode_status == ArtModeStatus.Unsupported:
+            if (
+                self._ws.artmode_status == ArtModeStatus.Unsupported
+                and self._get_device_spec("FrameTVSupport") != "true"
+            ):
                 self.send_command(cmd_power_off)
             else:
                 self.send_command(f"{cmd_power_art},3000")


### PR DESCRIPTION
- Detect power status based on events (should improve status detection)
- Manage power off control for 2022 Frame TV (issue [#212](https://github.com/ollo69/ha-samsungtv-smart/issues/212))
- Remove option "Second to delay power ON Status"
- Fix app list not provided to `SamsungWS` class
