### PR TITLE
Update Key_codes.md - Fixed typo

### DIFF
--- a/docs/Key_codes.md
+++ b/docs/Key_codes.md
@@ -91,7 +91,7 @@ KEY_LEFT|NavigationLeft
 KEY_RIGHT|NavigationRight
 KEY_RETURN|NavigationReturn/Back
 KEY_ENTER|NavigationEnter
-KEY_EXIT|NevigationExit
+KEY_EXIT|NavigationExit
 
 *Media Keys*
 ____________


### PR DESCRIPTION
Fixed typo on line 94. NevigationExit to NavigationExit.