### PR TITLE
Added support for Samsung Monitors that support the SmartThings API

### DIFF
--- a/custom_components/samsungtv_smart/api/smartthings.py
+++ b/custom_components/samsungtv_smart/api/smartthings.py
@@ -17,6 +17,8 @@ API_DEVICES = f"{API_BASEURL}/devices"
 
 DEVICE_TYPE_OCF = "OCF"
 DEVICE_TYPE_NAME_TV = "Samsung OCF TV"
+DEVICE_TYPE_NAMES = ["Samsung OCF TV", "x.com.st.d.monitor"]
+
 
 COMMAND_POWER_OFF = {
     "capability": "switch",
@@ -337,7 +339,7 @@ class SmartThingsTV:
                 if device_label:
                     if label != device_label:
                         continue
-                elif dev.get("deviceTypeName", "") != DEVICE_TYPE_NAME_TV:
+                elif dev.get("deviceTypeName", "") not in DEVICE_TYPE_NAMES:
                     continue
 
                 result[device_id] = {


### PR DESCRIPTION
Some Samsung monitors act as regular Samsung TVs, like the Samsung G7. This adds support for these monitor types so they appear in the available TV list when adding a new device in HomeAssistant in the integration prompt. 